### PR TITLE
Fix authentication() and get_memebers_assignments()

### DIFF
--- a/edmodo_api.py
+++ b/edmodo_api.py
@@ -3,6 +3,7 @@ from lxml import html
 from collections import namedtuple
 
 BASE_URL = 'https://www.edmodo.com'
+LOGIN_URL = '{}/index/ajax-login'.format(BASE_URL)
 ASSIGNMENT_URL = '{}/assignment/ajax-get-submission-info'.format(BASE_URL)
 FILES_URL = '{}/file'.format(BASE_URL)
 GRADE_URL = '{}/assignment/ajax-grade-assignment'.format(BASE_URL)
@@ -33,8 +34,8 @@ class EdmodoGroup:
             'username': user,
             'password': pswd
         }
-        s.post(BASE_URL, data=user_data)
-        r = s.get(BASE_URL.format('/home'))
+        s.post(LOGIN_URL, data=user_data)
+        r = s.get(BASE_URL + '/home')
         s.headers['x-csrf-token'] = r.headers['x-csrf-token']
 
     def get_group_members(self):
@@ -47,7 +48,8 @@ class EdmodoGroup:
         return members
 
     def get_members_assignments(self, assignment_id):
-        if not self.members:
+        members = self.members
+        if not members:
             members = self.get_group_members()
 
         s = self._s


### PR DESCRIPTION
The URL for authentication seems to have changed.
The base https://www.edmodo.com/ didn't log me in when I tried sending my username and password.
Changed to a different URL that responds with some status JSON and an authenticated session cookie.

In `get_members_assignments` there is a minor bug that crashed the module for me when testing. (See changes in the code).
